### PR TITLE
Add IQueryable implementation for consul filter standard

### DIFF
--- a/src/Consul.Net.Microsoft.DependencyInjection/Consul.Net.Microsoft.DependencyInjection.csproj
+++ b/src/Consul.Net.Microsoft.DependencyInjection/Consul.Net.Microsoft.DependencyInjection.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build Information">
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -10,11 +10,9 @@
     <Description>Consul.Net.Microsoft.DependencyInjection is a library with tools to register Consul.Net on Microsoft DI container.</Description>
     <PackageTags>Consul; Consul.Net; Microsoft Depency Injection; DI; Service Discovery;</PackageTags>
     <PackageReleaseNotes>
-      - Add Consul client to DI;
-      - Add HostedService that when registered will automaticly register service
-      on consul when application starts and deregister when application stops;
+      - Update DI requirements for the new implementations on Client.Net library;
     </PackageReleaseNotes>
-    <Version>1.0.0-preview1</Version>
+    <Version>1.0.0-preview2</Version>
   </PropertyGroup>
 
   <ItemGroup Label="Package References">

--- a/src/Consul.Net.Util/Consul.Net.Util.csproj
+++ b/src/Consul.Net.Util/Consul.Net.Util.csproj
@@ -9,9 +9,9 @@
     <Description>Consul.Net.Util is a library that provides tools to help building Consul.Net library.</Description>
     <PackageTags>Consul; HttpClient; Service Discovery; Util;</PackageTags>
     <PackageReleaseNotes>
-      - Add interface and implementation for factory HTTP contents.
+      - Add Task extemsion that turns async methods into sync.
     </PackageReleaseNotes>
-    <Version>1.0.0-preview1</Version>
+    <Version>1.0.0-preview2</Version>
   </PropertyGroup>
 
   <ItemGroup Label="Package References">

--- a/src/Consul.Net.Util/Threading/TaskExtensions.cs
+++ b/src/Consul.Net.Util/Threading/TaskExtensions.cs
@@ -1,0 +1,27 @@
+namespace Consul.Net.Util.Threading
+{
+    using System;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Provide extensions for <see cref="Task"/>.
+    /// </summary>
+    public static class TaskExtensions
+    {
+        /// <summary>
+        /// Turns a asynchronous task into a synchronous processes.
+        /// </summary>
+        /// <remarks>This extension should be used only when asynchronous methods is not supported in anyway.</remarks>
+        /// <typeparam name="TResult">The asynchronous task result.</typeparam>
+        /// <param name="task">The <see cref="Task"/>.</param>
+        /// <returns>The task result.</returns>
+        public static TResult ToSync<TResult>(this Task<TResult> task)
+        {
+            _ = task ?? throw new ArgumentNullException(nameof(task));
+
+            return task
+                .GetAwaiter()
+                .GetResult();
+        }
+    }
+}

--- a/src/Consul.Net/AgentResources.cs
+++ b/src/Consul.Net/AgentResources.cs
@@ -1,20 +1,71 @@
 namespace Consul.Net
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Net.Http.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Consul.Net.Models;
+    using Consul.Net.Util.Threading;
+    using Flurl;
 
     /// <inheritdoc/>
     public sealed class AgentResources : IAgentResources
     {
+        private readonly HttpClient httpClient;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AgentResources"/> class.
         /// </summary>
+        /// <param name="httpClient">The configured <see cref="HttpClient"/> to comunicate with Consul `/agent/*` endpoints.</param>
         /// <param name="serviceResources">The <see cref="IAgentServiceResources"/> implementation.</param>
-        public AgentResources(IAgentServiceResources serviceResources)
+        /// <param name="serviceQueryableFactory">The <see cref="IQueryable{T}"/> of <see cref="AgentService"/> factory.</param>
+        public AgentResources(
+            HttpClient httpClient,
+            IAgentServiceResources serviceResources,
+            Func<Func<string, IEnumerable<AgentService>>, IQueryable<AgentService>> serviceQueryableFactory)
         {
+            _ = serviceQueryableFactory ?? throw new ArgumentNullException(nameof(serviceQueryableFactory));
+
+            this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             this.Service = serviceResources ?? throw new ArgumentNullException(nameof(serviceResources));
+            this.Services = serviceQueryableFactory(x => this.GetServicesAsync(x).ToSync());
         }
 
         /// <inheritdoc/>
         public IAgentServiceResources Service { get; }
+
+        /// <inheritdoc/>
+        public IQueryable<AgentService> Services { get; }
+
+        /// <inheritdoc/>
+        public Task<IEnumerable<AgentService>> GetServicesAsync(string? filter, CancellationToken cancellationToken = default)
+        {
+            return CreateTask();
+
+            async Task<IEnumerable<AgentService>> CreateTask()
+            {
+                var url = new Url("services");
+
+                if (filter is not null)
+                {
+                    _ = url.SetQueryParam("filter", filter);
+                }
+
+                var request = await this.httpClient
+                    .GetAsync(new Uri(url, UriKind.Relative), cancellationToken)
+                    .ConfigureAwait(false);
+
+                _ = request
+                    .EnsureSuccessStatusCode();
+
+                return (await request.Content
+                    .ReadFromJsonAsync<IDictionary<string, AgentService>>(cancellationToken: cancellationToken)
+                    .ConfigureAwait(false))
+                    .Select(x => x.Value);
+            }
+        }
     }
 }

--- a/src/Consul.Net/Consul.Net.csproj
+++ b/src/Consul.Net/Consul.Net.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build Information">
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -9,10 +9,10 @@
     <Description>Consul.Net is a library to comunicate with Consul Agent API.</Description>
     <PackageTags>Consul; HttpClient; Service Discovery;</PackageTags>
     <PackageReleaseNotes>
-      - Add Agent Service register resource
-      - Add Agent Service deregister resource
+      - Add Agent services resource;
+      - Add a IQueryable implementation that turns code into Consul Filter Expression;
     </PackageReleaseNotes>
-    <Version>1.0.0-preview1</Version>
+    <Version>1.0.0-preview2</Version>
   </PropertyGroup>
 
   <ItemGroup Label="Package References">

--- a/src/Consul.Net/Filtering/ExpressionNormalizer.cs
+++ b/src/Consul.Net/Filtering/ExpressionNormalizer.cs
@@ -1,0 +1,47 @@
+namespace Consul.Net.Filtering
+{
+    using System;
+    using System.Linq;
+    using System.Linq.Expressions;
+
+    internal sealed class ExpressionNormalizer : ExpressionVisitor
+    {
+        public static Expression Normalize(Expression expression)
+        {
+            _ = expression ?? throw new ArgumentNullException(nameof(expression));
+
+            var parser = new ExpressionNormalizer();
+
+            return parser.Visit(expression);
+        }
+
+        /// <inheritdoc/>
+        protected override Expression VisitLambda<T>(Expression<T> node)
+        {
+            return node.Body;
+        }
+
+        /// <inheritdoc/>
+        protected override Expression VisitMethodCall(MethodCallExpression node)
+        {
+            if (node.Method.DeclaringType == typeof(Queryable))
+            {
+                return node.Method.Name switch
+                {
+                    "Where" => this.Visit(node.Arguments[1]),
+                    _ when node.Arguments.Count == 1 => this.Visit(node.Arguments.Single()),
+                    _ => throw new NotSupportedException(),
+                };
+            }
+
+            return base.VisitMethodCall(node);
+        }
+
+        /// <inheritdoc/>
+        protected override Expression VisitUnary(UnaryExpression node) => node.NodeType switch
+        {
+            ExpressionType.Quote => this.Visit(node.Operand),
+            _ => base.VisitUnary(node),
+        };
+    }
+}

--- a/src/Consul.Net/Filtering/ExpressionParser.cs
+++ b/src/Consul.Net/Filtering/ExpressionParser.cs
@@ -1,0 +1,164 @@
+namespace Consul.Net.Filtering
+{
+    using System;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Text;
+    using static System.Linq.Expressions.ExpressionType;
+
+    /// <summary>
+    /// Parse a <see cref="Expression"/> into consul Filter expression
+    /// using the <see cref="ExpressionVisitor"/>.
+    /// </summary>
+    internal sealed class ExpressionParser : ExpressionVisitor
+    {
+        private readonly StringBuilder builder;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExpressionParser"/> class.
+        /// </summary>
+        public ExpressionParser()
+        {
+            this.builder = new StringBuilder();
+        }
+
+        /// <summary>
+        /// Parse a <see cref="Expression"/> into consul Filter expression
+        /// using the <see cref="ExpressionParser"/>.
+        /// </summary>
+        /// <param name="expression">The <see cref="Expression"/> to be parsed.</param>
+        /// <returns>A string contanig the consul filter expression.</returns>
+        public static string Parse(Expression expression)
+        {
+            var visitor = Activator.CreateInstance<ExpressionParser>();
+
+            _ = visitor.Visit(expression);
+
+            return visitor.ToString();
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+            => this.builder.ToString();
+
+        /// <inheritdoc/>
+        protected override Expression VisitBinary(BinaryExpression node)
+        {
+            var parsedOperator = ParseOperator(node.NodeType, node.Left, node.Right);
+
+            if (node.NodeType == OrElse)
+            {
+                _ = this.builder.Append('(');
+                _ = this.Visit(node);
+                _ = this.builder.Append('(');
+
+                return node;
+            }
+
+            _ = this.Visit(node.Left);
+
+            _ = this.builder.Append($" {parsedOperator} ");
+
+            _ = this.Visit(node.Right);
+
+            return node;
+        }
+
+        /// <inheritdoc/>
+        protected override Expression VisitConstant(ConstantExpression node)
+        {
+            _ = this.builder.Append(node.Value ?? "empty");
+
+            return node;
+        }
+
+        /// <inheritdoc/>
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            _ = this.builder.Append(node.Member.Name);
+
+            return node;
+        }
+
+        /// <inheritdoc/>
+        protected override Expression VisitMethodCall(MethodCallExpression node)
+        {
+            if (node.Method.Name == "get_Item")
+            {
+                _ = this.Visit(node.Object);
+
+                _ = this.builder.Append('.');
+
+                _ = this.Visit(node.Arguments.Single());
+            }
+            else if (node.Method.Name == "Contains" && node.Object is not null)
+            {
+                _ = this.Visit(node.Object);
+
+                _ = this.builder.Append(" contains ");
+
+                _ = this.builder.Append('"');
+                _ = this.Visit(node.Arguments.Single());
+                _ = this.builder.Append('"');
+            }
+            else if (node.Method.Name == "Contains" && node.Object is null && node.Arguments.Count == 2)
+            {
+                _ = this.builder.Append('"');
+                _ = this.Visit(node.Arguments[1]);
+                _ = this.builder.Append('"');
+
+                _ = this.builder.Append(" in ");
+
+                _ = this.Visit(node.Arguments[0]);
+            }
+            else if (node.Method.Name == "IsNullOrEmpty")
+            {
+                _ = this.Visit(
+                    Expression.MakeBinary(
+                        Equal,
+                        node.Arguments.Single(),
+                        Expression.Constant(null)));
+            }
+
+            return node;
+        }
+
+        /// <inheritdoc/>
+        protected override Expression VisitUnary(UnaryExpression node)
+        {
+            if (node.NodeType == Not)
+            {
+                _ = this.builder.Append($"{ParseOperator(node.NodeType)} (");
+                _ = this.Visit(node.Operand);
+                _ = this.builder.Append(')');
+
+                return node;
+            }
+
+            _ = this.builder.Append($" {ParseOperator(node.NodeType)} ");
+
+            _ = this.Visit(node.Operand);
+
+            return node;
+        }
+
+        private static string ParseOperator(
+            ExpressionType expressionType,
+            Expression? left = default,
+            Expression? right = default) => expressionType switch
+            {
+                AndAlso => "and",
+                Equal when
+                    (left is ConstantExpression x && x.Value is null)
+                    || (right is ConstantExpression y && y.Value is null) => "is",
+                Equal => "==",
+                NotEqual when
+                    (left is ConstantExpression x && x.Value is null)
+                    || (right is ConstantExpression y && y.Value is null) => "is not",
+                NotEqual => "!=",
+                OrElse => "or",
+                Not => "not",
+                _ => string.Empty,
+            };
+    }
+}

--- a/src/Consul.Net/Filtering/FilterQueryProvider.cs
+++ b/src/Consul.Net/Filtering/FilterQueryProvider.cs
@@ -1,0 +1,64 @@
+namespace Consul.Net.Filtering
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using Expression = System.Linq.Expressions.Expression;
+
+    /// <inheritdoc/>
+    public class FilterQueryProvider<TService> : IQueryProvider
+    {
+        private readonly Func<string, IEnumerable<TService>> filterExecuter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FilterQueryProvider{TService}"/> class.
+        /// </summary>
+        /// <param name="filterExecuter">Factory that turns a in string filter into an <see cref="IEnumerable{T}"/> of <typeparamref name="TService"/>.</param>
+        public FilterQueryProvider(Func<string, IEnumerable<TService>> filterExecuter)
+        {
+            this.filterExecuter = filterExecuter;
+        }
+
+        /// <inheritdoc/>
+        public IQueryable CreateQuery(Expression expression)
+            => this.CreateQuery<TService>(expression);
+
+        /// <inheritdoc/>
+        public IQueryable<TElement> CreateQuery<TElement>(Expression expression)
+            => (IQueryable<TElement>)new FilterQueryable<TService>(this)
+            {
+                Expression = ExpressionNormalizer.Normalize(expression),
+            };
+
+        /// <inheritdoc/>
+        public object Execute(Expression expression)
+        {
+            expression = ExpressionNormalizer.Normalize(expression);
+
+            return this.filterExecuter(ExpressionParser.Parse(expression));
+        }
+
+        /// <inheritdoc/>
+        public TResult Execute<TResult>(Expression expression)
+        {
+            var enumerationMap = new Dictionary<string, Func<IEnumerable<TResult>, TResult>>
+            {
+                { "First", x => x.First() },
+                { "FirstOrDefault", x => x.FirstOrDefault() },
+                { "Single", x => x.Single() },
+                { "SingleOrDefault", x => x.SingleOrDefault() },
+            };
+
+            if (expression is not MethodCallExpression methodCallExpression ||
+                !enumerationMap.TryGetValue(methodCallExpression.Method.Name, out var enumerableResolver))
+            {
+                throw new NotSupportedException();
+            }
+
+            var results = (IEnumerable<TResult>)this.Execute(methodCallExpression.Arguments.Single());
+
+            return enumerableResolver(results);
+        }
+    }
+}

--- a/src/Consul.Net/Filtering/FilterQueryable.cs
+++ b/src/Consul.Net/Filtering/FilterQueryable.cs
@@ -1,0 +1,39 @@
+namespace Consul.Net.Filtering
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+
+    /// <inheritdoc/>
+    public class FilterQueryable<TService> : IQueryable<TService>
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="FilterQueryable{TService}"/> class.
+        /// </summary>
+        /// <param name="provider">The <see cref="IQueryProvider"/> implementaion.</param>
+        public FilterQueryable(IQueryProvider provider)
+        {
+            this.Expression = Expression.Constant(this);
+            this.Provider = provider;
+        }
+
+        /// <inheritdoc/>
+        public Type ElementType => typeof(TService);
+
+        /// <inheritdoc/>
+        public Expression Expression { get; set; }
+
+        /// <inheritdoc/>
+        public IQueryProvider Provider { get; }
+
+        /// <inheritdoc/>
+        public IEnumerator<TService> GetEnumerator()
+            => ((IEnumerable<TService>)this.Provider.Execute(this.Expression)).GetEnumerator();
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator()
+            => this.GetEnumerator();
+    }
+}

--- a/src/Consul.Net/IAgentResources.cs
+++ b/src/Consul.Net/IAgentResources.cs
@@ -1,5 +1,12 @@
 namespace Consul.Net
 {
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Consul.Net.Models;
+
     /// <summary>
     /// Interface resposible to comunicate with `/agent` consul endpoint.
     /// </summary>
@@ -8,6 +15,20 @@ namespace Consul.Net
         /// <summary>
         /// Gets the entrypoint communication with `/agent/service/*` Consul endpoint.
         /// </summary>
-        IAgentServiceResources Service { get;  }
+        IAgentServiceResources Service { get; }
+
+        /// <summary>
+        /// Gets the queryable entrypoint to filter services using the `/agent/services` Consul endpoint.
+        /// </summary>
+        IQueryable<AgentService> Services { get; }
+
+        /// <summary>
+        /// Gets a list of serviceusing the `/agent/services` Consul endpoint.
+        /// </summary>
+        /// <param name="filter">The consul filter expression.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>A list of <see cref="AgentService"/>.</returns>
+        /// <exception cref="HttpRequestException">Throwed when an unsuccessful status code was returnd by the service.</exception>
+        Task<IEnumerable<AgentService>> GetServicesAsync(string? filter = default, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Consul.Net/Models/AgentService.cs
+++ b/src/Consul.Net/Models/AgentService.cs
@@ -1,0 +1,63 @@
+namespace Consul.Net.Models
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// aaaaaaaaaaaaa.
+    /// </summary>
+    public sealed class AgentService
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentService"/> class.
+        /// </summary>
+        public AgentService()
+        {
+            this.Address = string.Empty;
+            this.Datacenter = string.Empty;
+            this.ID = string.Empty;
+            this.Meta = new Dictionary<string, string>();
+            this.Service = string.Empty;
+            this.Tags = new HashSet<string>();
+        }
+
+        /// <summary>
+        /// Gets or Sets aaa.
+        /// </summary>
+        public string Address { get; set; }
+
+        /// <summary>
+        /// Gets or Sets aaaa.
+        /// </summary>
+        public string Datacenter { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether aaaaa.
+        /// </summary>
+        public bool EnableTagOverride { get; set; }
+
+        /// <summary>
+        /// Gets or Sets aaaaaa.
+        /// </summary>
+        public string ID { get; set; }
+
+        /// <summary>
+        /// Gets aaaaaaa.
+        /// </summary>
+        public IDictionary<string, string> Meta { get; }
+
+        /// <summary>
+        /// Gets or Sets aaaaaaaa.
+        /// </summary>
+        public int Port { get; set; }
+
+        /// <summary>
+        /// Gets or Sets aaaaaa.
+        /// </summary>
+        public string Service { get; set; }
+
+        /// <summary>
+        /// Gets or Sets aaaaaaa.
+        /// </summary>
+        public IEnumerable<string> Tags { get; set; }
+    }
+}

--- a/test/Consul.Net.UnitTests/AgentResourcesTests.cs
+++ b/test/Consul.Net.UnitTests/AgentResourcesTests.cs
@@ -1,8 +1,11 @@
 namespace Consul.Net
 {
     using System;
+    using System.Linq;
+    using Consul.Net.Models;
     using FluentAssertions;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSubstitute;
 
     [TestClass]
     public sealed class AgentResourcesTests
@@ -12,11 +15,23 @@ namespace Consul.Net
         {
             // Act
             Action constructingWithoutServiceResources =
-                () => _ = new AgentResources(default!);
+                () => _ = new AgentResources(default!, Substitute.For<IQueryable<AgentService>>());
 
             // Assert
             _ = constructingWithoutServiceResources.Should().ThrowExactly<ArgumentNullException>()
                 .Which.ParamName.Should().Be("serviceResources");
+        }
+
+        [TestMethod]
+        public void ConstructingWithoutServicesShouldThrowArgumentNullException()
+        {
+            // Act
+            Action constructingWithoutServices =
+                () => _ = new AgentResources(Substitute.For<IAgentServiceResources>(), default!);
+
+            // Assert
+            _ = constructingWithoutServices.Should().ThrowExactly<ArgumentNullException>()
+                .Which.ParamName.Should().Be("services");
         }
     }
 }


### PR DESCRIPTION
This PR adds the following new features to the `Consul.Net` :

- IQueryble and IQueryProvider implementation to write fluently consul filtering expression
- Adds a resource to call `/agent/services` endpoint